### PR TITLE
Supoprt ghq default direcotry(~/.ghq).

### DIFF
--- a/helm-ghq.el
+++ b/helm-ghq.el
@@ -52,12 +52,21 @@
   `(buffer-substring-no-properties
     (line-beginning-position) (line-end-position)))
 
+(defun helm-ghq--root-fallback ()
+  (erase-buffer)
+  (unless (zerop (process-file "git" nil t nil "config" "ghq.root"))
+    (error "Failed: Can't find ghq.root"))
+  (goto-char (point-min))
+  (expand-file-name (helm-ghq--line-string)))
+
 (defun helm-ghq--root ()
   (with-temp-buffer
-    (unless (zerop (process-file "ghq" nil t nil "root"))
-      (error "Failed: 'ghq root'"))
+    (process-file "ghq" nil t nil "root")
     (goto-char (point-min))
-    (helm-current-line-contents)))
+    (let ((output (helm-ghq--line-string)))
+      (if (string-match-p "\\`No help topic" output)
+          (helm-ghq--root-fallback)
+        (expand-file-name output)))))
 
 (defun helm-ghq--list-candidates ()
   (with-temp-buffer


### PR DESCRIPTION
Emacs lispをinit.el以外で初めて書いてPRさせて頂きました。
部分的に動作させながらコードを理解して、標準出力させた値を元にrootディレクトリをとってきているところは理解できたのですが、純粋に標準出力だけを実現する方法がわからずcall-processでechoしてしまいました。
(princなどでは文字列が評価されて2回出力されてしまう)
Emacs Lisp で prin1とprincとprintの違い - ながとダイアリー
http://d.hatena.ne.jp/mclh46/20100914/1284465897

その他も含めて問題があれば再度修正後にPRさせて貰いたいと思うのでレビューよろしくお願いします。
