### PR TITLE
Fix obsolete function

### DIFF
--- a/helm-ghq.el
+++ b/helm-ghq.el
@@ -34,7 +34,6 @@
 (defvar helm-source-ghq
   `((name . "ghq")
     (candidates . helm-ghq--list-candidates)
-    (match . helm-files-match-only-basename)
     (filtered-candidate-transformer
      . (lambda (candidates _source)
          (cl-loop for i in candidates


### PR DESCRIPTION
The helm-files-match-only-basename function was deleted from
helm-utils.el at 2014/12/07.
