### PR TITLE
Fix an error occured when `helm-ff-transformer-show-only-basename` is true

### DIFF
--- a/helm-ghq.el
+++ b/helm-ghq.el
@@ -45,8 +45,8 @@
      . (lambda (candidates _source)
          (cl-loop for i in candidates
                   if helm-ff-transformer-show-only-basename
-                  collect (cons (helm-basename i) i)
-                  else collect i)))
+                  collect i
+                  else collect (cons (cdr i) (cdr i)))))
     (keymap . ,helm-generic-files-map)
     (help-message . helm-generic-file-help-message)
     (mode-line . helm-generic-file-mode-line-string)

--- a/helm-ghq.el
+++ b/helm-ghq.el
@@ -41,12 +41,11 @@
   `((name . "ghq")
     (candidates . helm-ghq--list-candidates)
     (match . helm-ghq--files-match-only-basename)
-    (filtered-candidate-transformer
-     . (lambda (candidates _source)
-         (cl-loop for i in candidates
-                  if helm-ff-transformer-show-only-basename
-                  collect i
-                  else collect (cons (cdr i) (cdr i)))))
+    (filter-one-by-one
+     . (lambda (candidate)
+         (if helm-ff-transformer-show-only-basename
+           candidate
+           (cons (cdr candidate) (cdr candidate)))))
     (keymap . ,helm-generic-files-map)
     (help-message . helm-generic-file-help-message)
     (mode-line . helm-generic-file-mode-line-string)


### PR DESCRIPTION
In `filtered-candidate-transformer` part of `helm-source-ghq`, calling `helm-basename` fails when `helm-ff-transformer-show-only-basename` is true, because the element of `candidate` is not a string value but a value like `("user/repo-name" . /path/to/ghq/root/github.com/user/repo-name)` (see https://github.com/emacs-helm/helm/blob/a87cb96edeb180e22401572963f99471c5f1c686/helm-source.el#L246-L248).

I fixed it so that it can process candidates properly, and I also changed it to `filter-one-by-one`, because I noticed that it is more faster than using `filtered-candidate-transformer` (see https://github.com/emacs-helm/helm/blob/a87cb96edeb180e22401572963f99471c5f1c686/helm-source.el#L255-L264).