### PR TITLE
Make path of ghq customizable

### DIFF
--- a/helm-ghq.el
+++ b/helm-ghq.el
@@ -32,6 +32,12 @@
 (defun helm-ghq--open-dired (file)
   (dired (file-name-directory file)))
 
+(defcustom helm-ghq-ghq-executable
+  "ghq"
+  "Name of the ghq executable to use."
+  :type 'string
+  :group 'helm-ghq)
+
 (defvar helm-ghq--action
   '(("Open File" . find-file)
     ("Open File other window" . find-file-other-window)
@@ -81,7 +87,7 @@ even is \" -b\" is specified."
 
 (defun helm-ghq--root ()
   (with-temp-buffer
-    (process-file "ghq" nil t nil "root")
+    (process-file helm-ghq-ghq-executable nil t nil "root")
     (goto-char (point-min))
     (let ((output (helm-ghq--line-string)))
       (if (string-match-p "\\`No help topic" output)
@@ -90,7 +96,7 @@ even is \" -b\" is specified."
 
 (defun helm-ghq--list-candidates ()
   (with-temp-buffer
-    (unless (zerop (call-process "ghq" nil t nil "list" "--full-path"))
+    (unless (zerop (call-process helm-ghq-ghq-executable nil t nil "list" "--full-path"))
       (error "Failed: ghq list --full-path"))
     (let ((ghq-root (helm-ghq--root))
           paths)

--- a/helm-ghq.el
+++ b/helm-ghq.el
@@ -127,7 +127,7 @@ even is \" -b\" is specified."
 
 (defun helm-ghq--update-repository (repo)
   (let ((user-project (helm-ghq--repo-to-user-project repo)))
-    (async-shell-command (concat "ghq get -u " user-project))))
+    (async-shell-command (concat helm-ghq-ghq-executable " get -u " user-project))))
 
 (defun helm-ghq--source-update (repo)
   (helm-build-sync-source "Update Repository"


### PR DESCRIPTION
In the case the environment variable `PATH` for emacs' process is not correct, one can want to desigate `ghq` executable explicitly.  This change is a mimic of the package `ag`.