### PR TITLE
Refactor

### DIFF
--- a/helm-ghq.el
+++ b/helm-ghq.el
@@ -171,12 +171,10 @@ even is \" -b\" is specified."
 			  helm-ghq-command-ghq nil t nil
 			  helm-ghq-command-ghq-arg-list))
       (error "Failed: Can't get ghq list candidates"))
-    (let ((ghq-root (helm-ghq--root))
-          paths)
+    (let ((paths))
       (goto-char (point-min))
       (while (not (eobp))
-        (let ((path (helm-ghq--line-string)))
-          (push (cons (file-relative-name path ghq-root) path) paths))
+	(push (helm-ghq--line-string) paths)
         (forward-line 1))
       (reverse paths))))
 


### PR DESCRIPTION
I believe it has not needed to make the following alist since helm-v2.2.0.

``` lisp
(("github.com/masutaka/emacs-helm-ghq" . "/Users/masutaka/src/github.com/masutaka/emacs-helm-ghq"))
```

Makes the following list from this change.

``` lisp
("/Users/masutaka/src/github.com/masutaka/emacs-helm-ghq")
```

See also  #15
